### PR TITLE
Use runtime arguments in Divan benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ digest = { version = "0.10.7", default-features = false, features = ["block-buff
 hex-literal = "0.4.1"
 
 [dev-dependencies]
-divan = "0.1.2"
+divan = "0.1.11"
 expect-test = "1.4.1"
 hex = "0.4.3"
 quickcheck = "1.0.3"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 areion = { path = ".." }
 blake3 = "1.5.0"
-divan = "0.1.2"
+divan = "0.1.11"
 sha2 = { version = "0.10.6", default-features = false, features = ["asm"] }
 
 [[bench]]

--- a/benchmarks/benches/benchmarks.rs
+++ b/benchmarks/benches/benchmarks.rs
@@ -44,59 +44,59 @@ fn areion512_dm(b: Bencher) {
 
 const LENS: &[usize] = &[16, 256, 1024, 16 * 1024, 1024 * 1024];
 
-#[divan::bench(consts = LENS)]
-fn areion512_md<const LEN: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn areion512_md(bencher: divan::Bencher, len: usize) {
     bencher
-        .with_inputs(|| vec![0u8; LEN])
-        .counter(BytesCount::new(LEN))
+        .with_inputs(|| vec![0u8; len])
+        .counter(BytesCount::new(len))
         .bench_refs(|block| areion::Areion512Md::default().chain_update(block).finalize());
 }
 
-#[divan::bench(consts = LENS)]
-fn areion512_mmo<const LEN: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn areion512_mmo(bencher: divan::Bencher, len: usize) {
     bencher
-        .with_inputs(|| vec![0u8; LEN])
-        .counter(BytesCount::new(LEN))
+        .with_inputs(|| vec![0u8; len])
+        .counter(BytesCount::new(len))
         .bench_refs(|block| areion::Areion512Mmo::default().chain_update(block).finalize());
 }
 
-#[divan::bench(consts = LENS)]
-fn areion256_512_sponge<const LEN: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn areion256_512_sponge(bencher: divan::Bencher, len: usize) {
     bencher
-        .with_inputs(|| vec![0u8; LEN])
-        .counter(BytesCount::new(LEN))
+        .with_inputs(|| vec![0u8; len])
+        .counter(BytesCount::new(len))
         .bench_refs(|block| Areion256Sponge::new().chain_update(block).finalize());
 }
 
-#[divan::bench(consts = LENS)]
-fn areion512_haifa<const LEN: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn areion512_haifa(bencher: divan::Bencher, len: usize) {
     bencher
-        .with_inputs(|| vec![0u8; LEN])
-        .counter(BytesCount::new(LEN))
+        .with_inputs(|| vec![0u8; len])
+        .counter(BytesCount::new(len))
         .bench_refs(|block| AreionHaifa512::new().chain_update(block).finalize());
 }
 
-#[divan::bench(consts = LENS)]
-fn sha256<const LEN: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn sha256(bencher: divan::Bencher, len: usize) {
     bencher
-        .with_inputs(|| vec![0u8; LEN])
-        .counter(BytesCount::new(LEN))
+        .with_inputs(|| vec![0u8; len])
+        .counter(BytesCount::new(len))
         .bench_refs(|block| Sha256::new().chain_update(block).finalize());
 }
 
-#[divan::bench(consts = LENS)]
-fn blake3<const LEN: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn blake3(bencher: divan::Bencher, len: usize) {
     bencher
-        .with_inputs(|| vec![0u8; LEN])
-        .counter(BytesCount::new(LEN))
+        .with_inputs(|| vec![0u8; len])
+        .counter(BytesCount::new(len))
         .bench_refs(|block| blake3::hash(block));
 }
 
-#[divan::bench(consts = LENS)]
-fn sha512<const LEN: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn sha512(bencher: divan::Bencher, len: usize) {
     bencher
-        .with_inputs(|| vec![0u8; LEN])
-        .counter(BytesCount::new(LEN))
+        .with_inputs(|| vec![0u8; len])
+        .counter(BytesCount::new(len))
         .bench_refs(|block| Sha512::new().chain_update(block).finalize());
 }
 


### PR DESCRIPTION
The new [`args`](https://docs.rs/divan/latest/divan/attr.bench.html#args) option greatly reduces compile times and is not limited to arrays/slices.